### PR TITLE
fix: allow overlay to work below the fold

### DIFF
--- a/src/components/FigmaOverlay.ce.vue
+++ b/src/components/FigmaOverlay.ce.vue
@@ -153,7 +153,7 @@ p {
 }
 
 #container {
-	position: absolute;
+	position: fixed;
 	bottom: 1rem;
 	left: 1rem;
 	padding: 16px;
@@ -206,7 +206,7 @@ label {
 }
 
 #figmaOverlay {
-	position: absolute;
+	position: fixed;
 	z-index: 9999;
 	top: 0px;
 	left: 0px;


### PR DESCRIPTION
- `position: absolute` prevents the toggle button and overlay from working on pages that have scrollbars since the overlay will be stuck at the top of the page
- using `position: fixed`, the overlay and settings container can always show on a page